### PR TITLE
 내서재, 찜하기 서적 가져오는 옵션 추가

### DIFF
--- a/controllers/book.controller.js
+++ b/controllers/book.controller.js
@@ -1,5 +1,6 @@
 const bookServ = require('../services/book.service');
 const myUtil = require('../utils/myutil.js');
+const {authMiddleware} = require('../middlewares/middleware');
 
 async function createBook(req, res) {
   const book = ({
@@ -21,8 +22,11 @@ async function createBook(req, res) {
 }
 
 const findBooks = async (req, res) => {
+  if (req.query.myBookshelve || req.query.myFavorite) {
+    authMiddleware(req, res, () => {});
+  }
   let serchOption = req.query;
-  serchOption = { ...serchOption, booksId: req.params.id };
+  serchOption = { ...serchOption, booksId: req.params.id, usersId: req.userInfo?.id };
   const result = await bookServ.findBooks(serchOption);
   res.json(result);
 };

--- a/db/openapi/createbookdata.js
+++ b/db/openapi/createbookdata.js
@@ -31,7 +31,7 @@ function getbookListUrl(pageNumber) {
 }
 
 function getBookDetail(isbn13) {
-  return `http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx?ttbkey=${API_KEY}&itemIdType=ISBN13&ItemId=${isbn13}&output=js&Version=20131101&OptResult=ebookList,usedList,Toc,ratingInfo,authors`;
+  return `http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx?ttbkey=${API_KEY}&itemIdType=ISBN13&ItemId=${isbn13}&output=js&Version=20131101&Cover=Big&OptResult=ebookList,usedList,Toc,ratingInfo,authors`;
 }
 
 function getBookPath(idx) {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 내서재, 찜하기 서적 가져오는 옵션 추가
- 찜하기 & 목록 10개만 가져오기
  - <URI>/books?limit=10&myFavorite=true
- 내서재 & 목록 10개만 가져오기
   - <URI>/books?limit=10&myBookshelve=true

2. 서적 이미지 해상도 증가
- 85pixel -> 200pixel
<br />