### PR TITLE
Add: DB Index, 북리스트 추가

### DIFF
--- a/controllers/book.controller.js
+++ b/controllers/book.controller.js
@@ -36,7 +36,7 @@ const findBooks = async (req, res) => {
 };
 
 const dbIndexUniqueTitle = async (req, res) => {
-  const result = await bookServ.dbIndexUniqueTitle;
+  const result = await bookServ.dbIndexUniqueTitle();
   res.json(result);
 };
 

--- a/controllers/book.controller.js
+++ b/controllers/book.controller.js
@@ -1,6 +1,6 @@
 const bookServ = require('../services/book.service');
 const myUtil = require('../utils/myutil.js');
-const {authMiddleware} = require('../middlewares/middleware');
+const { authMiddleware } = require('../middlewares/middleware');
 
 async function createBook(req, res) {
   const book = ({
@@ -26,9 +26,18 @@ const findBooks = async (req, res) => {
     authMiddleware(req, res, () => {});
   }
   let serchOption = req.query;
-  serchOption = { ...serchOption, booksId: req.params.id, usersId: req.userInfo?.id };
+  serchOption = {
+    ...serchOption,
+    booksId: req.params.id,
+    usersId: req.userInfo?.id,
+  };
   const result = await bookServ.findBooks(serchOption);
   res.json(result);
 };
 
-module.exports = { createBook, findBooks };
+const dbIndexUniqueTitle = async (req, res) => {
+  const result = await bookServ.dbIndexUniqueTitle;
+  res.json(result);
+};
+
+module.exports = { createBook, findBooks, dbIndexUniqueTitle };

--- a/db/openapi/createbookdata.js
+++ b/db/openapi/createbookdata.js
@@ -7,6 +7,7 @@ const API_KEY = process.env.API_KEY;
 const ORIGIN_URL = process.env.ORIGIN_URL || 'http://localhost:8000';
 const booksNum = 50;
 const pages = [1, 2, 3, 4];
+const getBooksList = ['ItemNewAll', 'ItemNewSpecial', 'Bestseller', 'BlogBest'];
 
 // true 로 할 경우
 // 알라딘에서 항시 최신 정보를 받음
@@ -26,8 +27,12 @@ const storeData = (data, path) => {
   }
 };
 
-function getbookListUrl(pageNumber) {
-  return `https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey=${API_KEY}&QueryType=ItemNewSpecial&MaxResults=${booksNum}&start=${pageNumber}&SearchTarget=Book&output=js&Version=20131101`;
+function getbookListUrl(getBooksList, pageNumber) {
+  return `https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey=${API_KEY}&QueryType=${getBooksList}&MaxResults=${booksNum}&start=${pageNumber}&SearchTarget=Book&output=js&Version=20131101`;
+}
+
+function getbookListUrl(getBooksList, pageNumber) {
+  return `https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey=${API_KEY}&QueryType=${getBooksList}&MaxResults=${booksNum}&start=${pageNumber}&SearchTarget=Book&output=js&Version=20131101`;
 }
 
 function getBookDetail(isbn13) {
@@ -39,10 +44,28 @@ function getBookPath(idx) {
 }
 
 function convertFormat(aladinItem) {
+  let authorName;
+  function checkAuthorName(property) {
+    property = aladinItem.subInfo.authors[0].authorName;
+    if (!property) {
+      return (authorName = '');
+    } else {
+      return (authorName = aladinItem.subInfo.authors[0].authorName);
+    }
+  }
+  let authorInfo;
+  function checkAuthorName(property) {
+    property = aladinItem.subInfo.authors[0].authorInfo;
+    if (!property) {
+      return (authorInfo = '');
+    } else {
+      return (authorInfo = aladinItem.subInfo.authors[0].authorInfo);
+    }
+  }
   let convertedItem = {
     title: aladinItem.title,
-    author: aladinItem.subInfo.authors[0].authorName,
-    authorIntro: aladinItem.subInfo.authors[0].authorInfo || '저자 소개 없음',
+    author: authorName || aladinItem.author,
+    authorIntro: authorInfo || '저자 소개 없음',
     category: aladinItem.categoryName.split('>')[1],
     coverImg: aladinItem.cover,
     introduction: aladinItem.description || '소개 없음',
@@ -67,33 +90,47 @@ const postBook = async book => {
     });
 };
 
+const dbindex = async () => {
+  await axios
+    .get(ORIGIN_URL + '/books/dbindex')
+    .then(v => {
+      console.log(`indexed`);
+    })
+    .catch(e => {
+      console.log(`wrong indexing`);
+    });
+};
+
 const createBookData = async () => {
   let savingCount = 0;
-  for (idx of pages) {
-    const responedListDB = await axios.get(getbookListUrl(idx));
-    for (book of responedListDB.data.item) {
-      let responedBookDB;
-      const bookPath = getBookPath(++savingCount);
-      if (false === fs.existsSync(bookPath) || !USE_CASHED_DATA) {
-        responedBookDB = (await axios.get(getBookDetail(book.isbn13))).data;
-        if (!responedBookDB.item) {
-          continue;
+  for (list of getBooksList) {
+    for (idx of pages) {
+      const responedListDB = await axios.get(getbookListUrl(list, idx));
+      for (book of responedListDB.data.item) {
+        let responedBookDB;
+        const bookPath = getBookPath(++savingCount);
+        if (false === fs.existsSync(bookPath) || !USE_CASHED_DATA) {
+          responedBookDB = (await axios.get(getBookDetail(book.isbn13))).data;
+          if (!responedBookDB.item) {
+            continue;
+          }
+          storeData(responedBookDB, bookPath);
+        } else {
+          let rawdata = fs.readFileSync(bookPath);
+          responedBookDB = JSON.parse(rawdata);
         }
-        storeData(responedBookDB, bookPath);
-      } else {
-        let rawdata = fs.readFileSync(bookPath);
-        responedBookDB = JSON.parse(rawdata);
-      }
 
-      const detailBook = {
-        ...responedBookDB,
-        ...responedBookDB.item[0],
-        item: undefined,
-      };
-      const millyBook = convertFormat(detailBook);
-      await postBook(millyBook);
+        const detailBook = {
+          ...responedBookDB,
+          ...responedBookDB.item[0],
+          item: undefined,
+        };
+        const millyBook = convertFormat(detailBook);
+        await postBook(millyBook);
+      }
     }
   }
+  await dbindex();
   return;
 };
 

--- a/db/openapi/createbookdata.js
+++ b/db/openapi/createbookdata.js
@@ -7,7 +7,7 @@ const API_KEY = process.env.API_KEY;
 const ORIGIN_URL = process.env.ORIGIN_URL || 'http://localhost:8000';
 const booksNum = 50;
 const pages = [1, 2, 3, 4];
-const getBooksList = ['ItemNewAll', 'ItemNewSpecial', 'Bestseller', 'BlogBest'];
+const kindOfBooks = ['ItemNewAll', 'ItemNewSpecial', 'Bestseller', 'BlogBest'];
 
 // true 로 할 경우
 // 알라딘에서 항시 최신 정보를 받음
@@ -44,28 +44,10 @@ function getBookPath(idx) {
 }
 
 function convertFormat(aladinItem) {
-  let authorName;
-  function checkAuthorName(property) {
-    property = aladinItem.subInfo.authors[0].authorName;
-    if (!property) {
-      return (authorName = '');
-    } else {
-      return (authorName = aladinItem.subInfo.authors[0].authorName);
-    }
-  }
-  let authorInfo;
-  function checkAuthorName(property) {
-    property = aladinItem.subInfo.authors[0].authorInfo;
-    if (!property) {
-      return (authorInfo = '');
-    } else {
-      return (authorInfo = aladinItem.subInfo.authors[0].authorInfo);
-    }
-  }
   let convertedItem = {
     title: aladinItem.title,
-    author: authorName || aladinItem.author,
-    authorIntro: authorInfo || '저자 소개 없음',
+    author: aladinItem.subInfo?.authors[0]?.authorName || '저자 이름 없음',
+    authorIntro: aladinItem.subInfo?.authors[0]?.authorInfo || '저자 소개 없음',
     category: aladinItem.categoryName.split('>')[1],
     coverImg: aladinItem.cover,
     introduction: aladinItem.description || '소개 없음',
@@ -103,7 +85,7 @@ const dbindex = async () => {
 
 const createBookData = async () => {
   let savingCount = 0;
-  for (list of getBooksList) {
+  for (list of kindOfBooks) {
     for (idx of pages) {
       const responedListDB = await axios.get(getbookListUrl(list, idx));
       for (book of responedListDB.data.item) {

--- a/models/book.dao.js
+++ b/models/book.dao.js
@@ -1,5 +1,18 @@
 const dataSource = require('.');
 
+const checkBook = async title => {
+  return await dataSource.query(
+    `
+    SELECT
+      *
+    FROM
+      books b
+    WHERE
+      title = "${title}"
+    `
+  );
+};
+
 const createBook = async ({
   title,
   coverImg,
@@ -41,7 +54,6 @@ const createBook = async ({
       page,
     ]
   );
-
   return insertStatus;
 };
 
@@ -83,14 +95,18 @@ const findBooks = async serchOption => {
   }
 
   const NOT_NULL_STATE = 'IS NOT NULL';
-  const categoriesIdState = categoriesId  ? `= '${categoriesId}'` : NOT_NULL_STATE;
-  const authorsIdState    = authorsId     ? `= '${authorsId}'`    : NOT_NULL_STATE;
-  const authorNameState   = authorName    ? `= '${authorName}'`   : NOT_NULL_STATE;
-  const booksIdStateState = booksId       ? `= '${booksId}'`      : NOT_NULL_STATE;
-  const categoryNameState = categoryName  ? `= '${categoryName}'` : NOT_NULL_STATE;
-  const publisherState    = publisher     ? `= '${publisher}'`    : NOT_NULL_STATE;
-  const userIdState       = usersId       ? `= '${usersId}'`      : NOT_NULL_STATE;
-  const limitState        = limit         ? `LIMIT ${limit}`      : '';
+  const categoriesIdState = categoriesId
+    ? `= '${categoriesId}'`
+    : NOT_NULL_STATE;
+  const authorsIdState = authorsId ? `= '${authorsId}'` : NOT_NULL_STATE;
+  const authorNameState = authorName ? `= '${authorName}'` : NOT_NULL_STATE;
+  const booksIdStateState = booksId ? `= '${booksId}'` : NOT_NULL_STATE;
+  const categoryNameState = categoryName
+    ? `= '${categoryName}'`
+    : NOT_NULL_STATE;
+  const publisherState = publisher ? `= '${publisher}'` : NOT_NULL_STATE;
+  const userIdState = usersId ? `= '${usersId}'` : NOT_NULL_STATE;
+  const limitState = limit ? `LIMIT ${limit}` : '';
   const orderPairMap = {
     rating: 'rating_score',
     page: 'page',
@@ -183,4 +199,18 @@ const findBooks = async serchOption => {
   return foundBooks;
 };
 
-module.exports = { createBook, createBookAuthor, findBooks };
+const dbIndexUniqueTitle = async () => {
+  return await dataSource.query(
+    `
+    CREATE UNIQUE INDEX title_idx ON books (title)
+    `
+  );
+};
+
+module.exports = {
+  createBook,
+  createBookAuthor,
+  findBooks,
+  checkBook,
+  dbIndexUniqueTitle,
+};

--- a/models/book.dao.js
+++ b/models/book.dao.js
@@ -1,6 +1,6 @@
 const dataSource = require('.');
 
-const checkBook = async title => {
+const findBooksByTitle = async title => {
   return await dataSource.query(
     `
     SELECT
@@ -211,6 +211,6 @@ module.exports = {
   createBook,
   createBookAuthor,
   findBooks,
-  checkBook,
+  findBooksByTitle,
   dbIndexUniqueTitle,
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "morgan": "^1.10.0",
     "pm2": "^5.2.2",
-    "prettier": "^2.7.1",
-    "nodemon": "^2.0.20"
+    "prettier": "^2.7.1"
   },
   "dependencies": {
     "async-mutex": "^0.4.0",
@@ -33,5 +32,5 @@
   },
   "optionalDependencies": {
     "fsevents": "*"
-}
+  }
 }

--- a/routes/book.router.js
+++ b/routes/book.router.js
@@ -7,6 +7,7 @@ const router = express.Router();
 router.post('/', asyncWrap(bookCtl.createBook));
 
 router.get('/', asyncWrap(bookCtl.findBooks));
+router.get('/dbindex', asyncWrap(bookCtl.dbIndexUniqueTitle));
 router.get('/:id', asyncWrap(bookCtl.findBooks));
 
 module.exports = router;

--- a/services/book.service.js
+++ b/services/book.service.js
@@ -5,7 +5,6 @@ const Mutex = require('async-mutex').Mutex;
 const mutex1 = new Mutex();
 const mutex2 = new Mutex();
 
-
 const createBook = async book => {
   const {
     title,
@@ -21,56 +20,64 @@ const createBook = async book => {
     page,
   } = book;
 
-  let categoryId;
-  await mutex1.runExclusive(async () => {
-    // Find category Entity
-    categoryId = await categoryDao.findCategoryByCateName(category).then(v => {
-      return { ...v }.id;
+  let [checkBook] = await bookDao.checkBook(title);
+  console.log('checkbox =', checkBook);
+  if (!checkBook) {
+    let categoryId;
+    await mutex1.runExclusive(async () => {
+      // Find category Entity
+      categoryId = await categoryDao
+        .findCategoryByCateName(category)
+        .then(v => {
+          return { ...v }.id;
+        });
+      if (!categoryId) {
+        // Create category Entity
+        categoryId = (await categoryDao.createCategory(category)).insertId;
+      }
     });
 
-    if (!categoryId) {
-      // Create category Entity
-      categoryId = (await categoryDao.createCategory(category)).insertId;
-    }
-  })
-
-  // Create book Entity
-  const { insertId: bookId } = await bookDao.createBook({
-    title,
-    coverImg,
-    toc,
-    introduction,
-    categoryId,
-    publishTime,
-    publisher,
-    ratingScore,
-    page,
-  });
-
-  let authorId;
-  await mutex2.runExclusive(async () => {
-    // Find author Entity
-    authorId = await authorDao.findAuthorByAuthorName(author).then(v => {
-      return { ...v }.id;
+    // Create book Entity
+    const { insertId: bookId } = await bookDao.createBook({
+      title,
+      coverImg,
+      toc,
+      introduction,
+      categoryId,
+      publishTime,
+      publisher,
+      ratingScore,
+      page,
     });
 
-    if (!authorId) {
-      // Create author Entity
-      authorId = (await authorDao.createAuthor(author, authorIntro)).insertId;
-    }
-  });
+    let authorId;
+    await mutex2.runExclusive(async () => {
+      // Find author Entity
+      authorId = await authorDao.findAuthorByAuthorName(author).then(v => {
+        return { ...v }.id;
+      });
 
-  // Create author Entity
-  await bookDao.createBookAuthor(bookId, authorId);
+      if (!authorId) {
+        // Create author Entity
+        authorId = (await authorDao.createAuthor(author, authorIntro)).insertId;
+      }
+    });
+
+    // Create author Entity
+    await bookDao.createBookAuthor(bookId, authorId);
+  }
 };
 
-const findBooks = async (serchOption) => {
-  serchOption = {...serchOption, order: convertOrderFormat(serchOption.order)};
+const findBooks = async serchOption => {
+  serchOption = {
+    ...serchOption,
+    order: convertOrderFormat(serchOption.order),
+  };
   return await bookDao.findBooks(serchOption);
-}
+};
 
-const convertOrderFormat = (orderText) => {
-  return orderText?.split(',')?.map( orderItem => {
+const convertOrderFormat = orderText => {
+  return orderText?.split(',')?.map(orderItem => {
     // ex) orderItem = -rating
     let orderTarget = orderItem;
     let orderFlag = 'ASC'; // 오름차순
@@ -81,7 +88,11 @@ const convertOrderFormat = (orderText) => {
       orderTarget = found[2]; // rating
     }
     return [orderTarget, orderFlag];
-  })
-}
+  });
+};
 
-module.exports = { createBook, findBooks };
+const dbIndexUniqueTitle = async () => {
+  return await bookDao.dbIndexUniqueTitle;
+};
+
+module.exports = { createBook, findBooks, dbIndexUniqueTitle };

--- a/services/book.service.js
+++ b/services/book.service.js
@@ -20,7 +20,7 @@ const createBook = async book => {
     page,
   } = book;
 
-  let [checkBook] = await bookDao.checkBook(title);
+  let [checkBook] = await bookDao.findBooksByTitle(title);
   console.log('checkbox =', checkBook);
   if (!checkBook) {
     let categoryId;

--- a/services/book.service.js
+++ b/services/book.service.js
@@ -92,7 +92,7 @@ const convertOrderFormat = orderText => {
 };
 
 const dbIndexUniqueTitle = async () => {
-  return await bookDao.dbIndexUniqueTitle;
+  return await bookDao.dbIndexUniqueTitle();
 };
 
 module.exports = { createBook, findBooks, dbIndexUniqueTitle };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- Book List 배열 추가
- DB index 
   

<br />

## :: 구현 사항 설명 

1. BookList 배열추가

- 기존 itemNewSpecial(주목할만한 신간 리스트) 단일 리스트에서,  하기 2개의 리스트 추가
    - Bestseller : 베스트셀러, BlogBest : 블로거 베스트셀러 (국내도서만 조회 가능)
- 추가 리스트의 책 상세내용 입력시 중복 책 제거 과정 추가 (unique index를 위한)


2.  DB index

- books 테이블의 title 컬럼에 대한 UNQUE INDEX 과정 추가

<br />

## :: 특이 사항

- 현재 이 PR은 반영이 된다면 좋겠지만, **독단적인 판단으로 진행한 건이기에 그렇기 않더라도 괜찮습니다.**
- **다른 백엔드 분들의 리뷰가 듣고 싶어서** 다들 바쁘신 와중에 실례를 무릅쓰고 올려봅니다.
